### PR TITLE
Add support for encoders with 3 states

### DIFF
--- a/libraries/Rotary/Rotary.cpp
+++ b/libraries/Rotary/Rotary.cpp
@@ -93,6 +93,32 @@ const unsigned char ttable[6][4] = {
   // R_CCW_BEGIN_M
   {R_START_M,            R_CCW_BEGIN_M,  R_START_M,    R_START | DIR_CCW},
 };
+#elif defined(TRISTATE)
+// Encoder with three states: 00, 10, 11
+// CW rotation down, CCW rotation up
+// 00 CCW_FINAL
+// 10 CCW_BEGIN
+// 11 R_START <-- Dent
+// 00 CW_BEGIN
+// 10 CW_FINAL
+#define R_CW_FINAL 0x1
+#define R_CW_BEGIN 0x2
+#define R_CCW_BEGIN 0x3
+#define R_CCW_FINAL 0x4
+
+const unsigned char ttable[5][4] = {
+  // R_START
+  {  R_CW_BEGIN, R_START, R_CCW_BEGIN, R_START },
+  // R_CW_FINAL
+  {  R_CW_BEGIN, R_START, R_CW_FINAL, R_START | DIR_CW},
+  // R_CW_BEGIN
+  {  R_CW_BEGIN, R_START, R_CW_FINAL, R_START},
+  // R_CCW_BEGIN
+  {  R_CCW_FINAL, R_START, R_CCW_BEGIN, R_START},
+  // R_CCW_FINAL
+  {  R_CCW_FINAL, R_START, R_CCW_BEGIN, R_START | DIR_CCW},
+};
+
 #else
 // Use the full-step state table (emits a code at 00 only)
 #define R_CW_FINAL 0x1

--- a/libraries/Rotary/Rotary.h
+++ b/libraries/Rotary/Rotary.h
@@ -10,6 +10,9 @@
 // Enable this to emit codes twice per step.
 //#define HALF_STEP
 
+// Enable this if your encoder has only 3 states.
+//#define TRISTATE
+
 // Enable weak pullups
 #define ENABLE_PULLUPS
 


### PR DESCRIPTION
These encoders skip one of the steps, but can still be used to
get accurate position.

With this tweak the encoder works perfectly. Thanks for such an amasing library!